### PR TITLE
Add org.apache.commons dependency with latest version to fix vulnerability of spring-openapi-starter-webmvc-ui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,12 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.modelmapper</groupId>


### PR DESCRIPTION
Add org.apache.commons dependency with latest version to fix vulnerability of spring-openapi-starter-webmvc-ui